### PR TITLE
Alternate format option for model experimentation

### DIFF
--- a/papers/emily_dorne/main.md
+++ b/papers/emily_dorne/main.md
@@ -113,10 +113,127 @@ CyFi was developed through an additional model experimentation phase, which comb
 
 The table below summarizes the matrix of experiments that were conducted. Model experimentation informed key decisions around which data sources were used, how satellite imagery was selected and processed, and which target variable was used.
 
-:::{figure} model_experimentation.png
-:label: fig:experiments
-:width: 100%
-Model experimentation summary, with final selections in bold.
+:::{table} Model experimentation summary, with final selection indicated by **.
+:label: tbl:model-experiments
+<table>
+  <tr>
+    <th>Training data points filter</th>
+    <td><ul><li>No filter</li>
+    <li>**Points within 550 meters of water</li>
+    <li>Points within 1,000m of water</li>
+    </ul></td>
+  </tr>
+  <tr>
+    <th rowspan="2">Sentinel-2 image query</th>
+    <th>Time window</th>
+    <td><ul><li>15 days</li>
+    <li>**30 days</li>
+    <li>60 days</li>
+    </ul></td>
+  </tr>
+  <tr>
+    <th>Bounding box around sample</th>
+    <td><ul><li>200m</li>
+    <li>500m</li>
+    <li>1,000m</li>
+    <li>**2,000m</li>
+    </ul></td>
+  </tr>
+  <tr>
+    <th rowspan="3">Sentinel-2 image selection</th>
+    <th>Cloud filter</th>
+    <td><ul><li>None</li>
+    <li>**<5%</li>
+    </ul></td>
+  </tr>
+  <tr>
+    <th>Missing data filter</th>
+    <td><ul><li>**None</li>
+    <li><1%</li>
+    </ul></td>
+  </tr>
+  <tr>
+    <th>Images per sample</th>
+    <td><ul><li>**1</li>
+    <li>Up to 15</li>
+    </ul></td>
+  </tr>
+  <tr>
+    <th rowspan="2">Sentinel-2 pixels used to generate features</th>
+    <th>Bounding box around sample point</th>
+    <td><ul>
+      <li>100m</li>
+      <li>200m</li>
+      <li>**2,000m</li>
+    </ul>
+  </li></td>
+  </tr>
+  <tr>
+    <th>Pixel filtering</th>
+    <td>
+    <ul>
+      <li>None</li>
+      <li>**Water pixels based on Sentinel-2 SCL band</li>
+    </ul>
+  </li></td>
+  </tr>
+  <tr>
+    <th>Sentinel-2 bands used</th>
+    <td>
+      <ul>
+        <li>Visible only</li>
+        <li>**Visible, aerosols, red edge, near infrared, water vapor, shortwave infrared, scene classification</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <th rowspan="2">Sentinel-2 features</th>
+    <th>Individual band statistics</th>
+    <td>
+      <ul>
+        <li>**Mean</li>
+        <li>Min</li>
+        <li>Max</li>
+        <li>**Range</li>
+        <li>**95th percentile</li>
+        <li>**Percent water</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <th>Multiple-band features</th>
+    <td>
+      <ul>
+        <li>**Blue/red ratio</li>
+        <li>**Blue/green ratio</li>
+        <li>**NDVI: visible red combined with three different red edge bands</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <th>Additional data sources beyond Sentinel-2</th>
+    <td><ul>
+      <li>Landsat imagery</li>
+      <li>HRRR climate (temperature, humidity)</li>
+      <li>Copernicus Digital Elevation Model</li>
+      <li>**UN FAO land cover</li>
+      <li>Latitude</li>
+      <li>Longitude</li>
+    </ul>
+    </td>
+  </tr>
+  <tr>
+    <th>Predicted target variable</th>
+    <td><ul>
+    <li>WHO severity category</li>
+    <li>Exact density (cells / mL)</li>
+    <li>**Log of exact density</li>
+  </ul>
+  </td>
+  </tr>
+</table>
+
+</table>
 :::
 
 During experimentation, the model was trained on roughly 13,000 samples and evaluated on a holdout validation set of roughly 5,000 samples. Performance was evaluated based on a combination of root mean squared error, mean absolute error, mean absolute percentage error, and regional root mean squared error, along with manual review and visualizations of predictions. Standard best practices were used to inform hyperparameters tuning for the final model.

--- a/papers/emily_dorne/main.md
+++ b/papers/emily_dorne/main.md
@@ -188,11 +188,12 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th rowspan="2">Sentinel-2 features</th>
-    <th colspan="3">Individual band statistics</th>
-    <th colspan="3">Multiple-band features</th>
+    <th colspan="2">Individual band</th>
+    <th colspan="2">Multiple band</th>
+    <th colspan="2">Metadata</th>
   </tr>
   <tr>
-    <td colspan="3">
+    <td colspan="2">
       <ul>
         <li>**Mean</li>
         <li>Min</li>
@@ -202,13 +203,17 @@ The table below summarizes the matrix of experiments that were conducted. Model 
         <li>**Percent water</li>
       </ul>
     </td>
-    <td colspan="3">
+    <td colspan="2">
       <ul>
         <li>**Blue/red ratio</li>
         <li>**Blue/green ratio</li>
-        <li>**NDVI: visible red combined with three different red edge bands</li>
+        <li>**NDVI: visible red combined with three red edge bands</li>
       </ul>
     </td>
+    <td colspan="2"><ul>
+    <li>**Month</li>
+    <li>**Days before sampling</li>
+    </ul></td>
   </tr>
   <tr>
     <th>Additional data sources beyond Sentinel-2</th>

--- a/papers/emily_dorne/main.md
+++ b/papers/emily_dorne/main.md
@@ -118,21 +118,21 @@ The table below summarizes the matrix of experiments that were conducted. Model 
 <table>
   <tr>
     <th>Training data points filter</th>
-    <td colspan="2"><ul><li>No filter</li>
+    <td colspan="6"><ul><li>No filter</li>
     <li>**Points within 550 meters of water</li>
     <li>Points within 1,000m of water</li>
     </ul></td>
   </tr>
   <tr>
     <th rowspan="2">Sentinel-2 image query</th>
-    <th>Time window</th>
-    <th>Bounding box around sample</th>
+    <th colspan="3">Time window</th>
+    <th colspan="3">Bounding box around sample</th>
   <tr>
-    <td><ul><li>15 days</li>
+    <td colspan="3"><ul><li>15 days</li>
     <li>**30 days</li>
     <li>60 days</li>
     </ul></td>
-    <td><ul><li>200m</li>
+    <td colspan="3"><ul><li>200m</li>
     <li>500m</li>
     <li>1,000m</li>
     <li>**2,000m</li>
@@ -140,37 +140,37 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th rowspan="2">Sentinel-2 image selection</th>
-    <th>Cloud filter</th>
-    <th>Missing data filter</th>
-    <th>Images per sample</th>
+    <th colspan="2">Cloud filter</th>
+    <th colspan="2">Missing data filter</th>
+    <th colspan="2">Images per sample</th>
   </tr>
   <tr>
-    <td><ul><li>None</li>
+    <td colspan="2"><ul><li>None</li>
       <li>**<5%</li>
       </ul>
     </td>
-    <td><ul><li>**None</li>
+    <td colspan="2"><ul><li>**None</li>
       <li><1%</li>
       </ul>
     </td>
-    <td><ul><li>**1</li>
+    <td colspan="2"><ul><li>**1</li>
       <li>Up to 15</li>
       </ul>
     </td>
   </tr>
   <tr>
     <th rowspan="2">Sentinel-2 pixels used to generate features</th>
-    <th>Bounding box around sample point</th>
-    <th>Pixel filtering</th>
+    <th colspan="3">Bounding box around sample point</th>
+    <th colspan="3">Pixel filtering</th>
   </tr>
   <tr>
-    <td><ul>
+    <td colspan="3"><ul>
       <li>100m</li>
       <li>200m</li>
       <li>**2,000m</li>
     </ul>
   </li></td>
-    <td>
+    <td colspan="3">
     <ul>
       <li>None</li>
       <li>**Water pixels based on Sentinel-2 SCL band</li>
@@ -179,7 +179,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th>Sentinel-2 bands used</th>
-    <td colspan="2">
+    <td colspan="6">
       <ul>
         <li>Visible only</li>
         <li>**Visible, aerosols, red edge, near infrared, water vapor, shortwave infrared, scene classification</li>
@@ -188,11 +188,11 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th rowspan="2">Sentinel-2 features</th>
-    <th>Individual band statistics</th>
-    <th>Multiple-band features</th>
+    <th colspan="3">Individual band statistics</th>
+    <th colspan="3">Multiple-band features</th>
   </tr>
   <tr>
-    <td>
+    <td colspan="3">
       <ul>
         <li>**Mean</li>
         <li>Min</li>
@@ -202,7 +202,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
         <li>**Percent water</li>
       </ul>
     </td>
-    <td>
+    <td colspan="3">
       <ul>
         <li>**Blue/red ratio</li>
         <li>**Blue/green ratio</li>
@@ -212,7 +212,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th>Additional data sources beyond Sentinel-2</th>
-    <td colspan="2"><ul>
+    <td colspan="6"><ul>
       <li>Landsat imagery</li>
       <li>HRRR climate (temperature, humidity)</li>
       <li>Copernicus Digital Elevation Model</li>
@@ -224,7 +224,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th>Predicted target variable</th>
-    <td colspan="2"><ul>
+    <td colspan="6"><ul>
     <li>WHO severity category</li>
     <li>Exact density (cells / mL)</li>
     <li>**Log of exact density</li>

--- a/papers/emily_dorne/main.md
+++ b/papers/emily_dorne/main.md
@@ -118,7 +118,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
 <table>
   <tr>
     <th>Training data points filter</th>
-    <td><ul><li>No filter</li>
+    <td colspan="2"><ul><li>No filter</li>
     <li>**Points within 550 meters of water</li>
     <li>Points within 1,000m of water</li>
     </ul></td>
@@ -126,13 +126,12 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   <tr>
     <th rowspan="2">Sentinel-2 image query</th>
     <th>Time window</th>
+    <th>Bounding box around sample</th>
+  <tr>
     <td><ul><li>15 days</li>
     <li>**30 days</li>
     <li>60 days</li>
     </ul></td>
-  </tr>
-  <tr>
-    <th>Bounding box around sample</th>
     <td><ul><li>200m</li>
     <li>500m</li>
     <li>1,000m</li>
@@ -140,36 +139,37 @@ The table below summarizes the matrix of experiments that were conducted. Model 
     </ul></td>
   </tr>
   <tr>
-    <th rowspan="3">Sentinel-2 image selection</th>
+    <th rowspan="2">Sentinel-2 image selection</th>
     <th>Cloud filter</th>
-    <td><ul><li>None</li>
-    <li>**<5%</li>
-    </ul></td>
-  </tr>
-  <tr>
     <th>Missing data filter</th>
-    <td><ul><li>**None</li>
-    <li><1%</li>
-    </ul></td>
+    <th>Images per sample</th>
   </tr>
   <tr>
-    <th>Images per sample</th>
+    <td><ul><li>None</li>
+      <li>**<5%</li>
+      </ul>
+    </td>
+    <td><ul><li>**None</li>
+      <li><1%</li>
+      </ul>
+    </td>
     <td><ul><li>**1</li>
-    <li>Up to 15</li>
-    </ul></td>
+      <li>Up to 15</li>
+      </ul>
+    </td>
   </tr>
   <tr>
     <th rowspan="2">Sentinel-2 pixels used to generate features</th>
     <th>Bounding box around sample point</th>
+    <th>Pixel filtering</th>
+  </tr>
+  <tr>
     <td><ul>
       <li>100m</li>
       <li>200m</li>
       <li>**2,000m</li>
     </ul>
   </li></td>
-  </tr>
-  <tr>
-    <th>Pixel filtering</th>
     <td>
     <ul>
       <li>None</li>
@@ -179,7 +179,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th>Sentinel-2 bands used</th>
-    <td>
+    <td colspan="2">
       <ul>
         <li>Visible only</li>
         <li>**Visible, aerosols, red edge, near infrared, water vapor, shortwave infrared, scene classification</li>
@@ -189,6 +189,9 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   <tr>
     <th rowspan="2">Sentinel-2 features</th>
     <th>Individual band statistics</th>
+    <th>Multiple-band features</th>
+  </tr>
+  <tr>
     <td>
       <ul>
         <li>**Mean</li>
@@ -199,9 +202,6 @@ The table below summarizes the matrix of experiments that were conducted. Model 
         <li>**Percent water</li>
       </ul>
     </td>
-  </tr>
-  <tr>
-    <th>Multiple-band features</th>
     <td>
       <ul>
         <li>**Blue/red ratio</li>
@@ -212,7 +212,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th>Additional data sources beyond Sentinel-2</th>
-    <td><ul>
+    <td colspan="2"><ul>
       <li>Landsat imagery</li>
       <li>HRRR climate (temperature, humidity)</li>
       <li>Copernicus Digital Elevation Model</li>
@@ -224,7 +224,7 @@ The table below summarizes the matrix of experiments that were conducted. Model 
   </tr>
   <tr>
     <th>Predicted target variable</th>
-    <td><ul>
+    <td colspan="2"><ul>
     <li>WHO severity category</li>
     <li>Exact density (cells / mL)</li>
     <li>**Log of exact density</li>


### PR DESCRIPTION
I tried out the idea of transposing the model experimentation table (using html), but it doesn't look great and takes up a ton of vertical space. It's possible it would look better if I did it in a slide and inserted an image, but as is wouldn't recommend incorporating this change. Wanted to PR to give you the option

Old:
![image](https://github.com/ejm714/scipy_proceedings/assets/46792169/a382d16e-510b-426c-98d4-12e6030746d5)


New:
![image](https://github.com/ejm714/scipy_proceedings/assets/46792169/fe16b73b-b48d-4a30-8956-8f2971a6edf2)
