### PR TITLE
CyAN v CyFi details, skew info

### DIFF
--- a/papers/emily_dorne/main.md
+++ b/papers/emily_dorne/main.md
@@ -357,7 +357,7 @@ Among the portion of the evaluation set captured by CyAN, CyFi detects blooms wi
 :::{figure} cyan_comparison.png
 :label: fig:cyan_comparison
 :width: 350px
-A comparison of CyFi and CyAN model accuracy on 756 ground sampled data points from across the U.S. A true positive (bloom presence) is where cyanobacteria density > 10,000 cells/mL.
+A comparison of CyFi and CyAN model accuracy on 756 ground sampled data points from across the U.S. A true positive (bloom presence) is where cyanobacteria density > 10,000 cells/mL. CyFi correctly identified 306 of 389 blooms, while CyAN correctly identified 169 (true positives). CyFi correctly identified 241 of 367 non-blooms, while CyAN correctly identified 332 (true negatives).
 :::
 
 In sum, we find that CyFi performs at least as well as a leading Sentinel-3 based tool, but has 10 times the coverage of water bodies across the U.S. due to the higher resolution of Sentinel-2 data. This dramatically expands the applicability of remote sensing-based estimates as a tool for management of HABs.

--- a/papers/emily_dorne/main.md
+++ b/papers/emily_dorne/main.md
@@ -252,7 +252,7 @@ The distance between each sample and the nearest water body was calculated using
   </tr>
   <tr>
     <td>Train the model to predict log density</td>
-    <td>We find transforming density into a log scale for model training and prediction yields better accuracy, as the underlying data is highly skewed. About 75% of samples have a density less than 400,000 cell/mL, but there are extreme outliers with densities as high as 800,000,000 cells/mL. A log scale helps the model learn that incorrectly estimating a density of 100,000 when the true density is 0 is much more important than incorrectly estimating a density of 1,100,000 when the true density is 1,000,000. The estimate a user sees has been converted back into (non-log) density.</td>
+    <td>We find transforming density into a log scale for model training and prediction yields better accuracy, as the underlying data is highly skewed by a small number of extremely high-density outliers. A log scale helps the model learn that incorrectly estimating a density of 100,000 when the true density is 0 is much more important than incorrectly estimating a density of 1,100,000 when the true density is 1,000,000. The estimate a user sees has been converted back into (non-log) density.</td>
   </tr>
 </table>
 :::


### PR DESCRIPTION
- Sentence on number of true positives and true negatives for CyFi and CyAN to aid interpretation of graph
- Adjust description of data skew. I decided not to include an exact number here, because it could get misleading about exactly which version of the data we're talking about (ie. whether or not it's filtered for water distance, filtered for sentinel-2 launch date, winsorized, etc)